### PR TITLE
routing improved for githib pages

### DIFF
--- a/portfolio/public/404.html
+++ b/portfolio/public/404.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Redirect</title>
+</head>
+<body>
+    <script>
+        (function() {
+        const redirect = window.location.pathname;
+        const query = window.location.search;
+        const hash = window.location.hash;
+        const target = '/?redirect=' + encodeURIComponent(redirect + query + hash);
+        window.location.replace(target);
+      })();
+    </script>
+</body>
+</html>

--- a/portfolio/src/App.jsx
+++ b/portfolio/src/App.jsx
@@ -2,18 +2,20 @@ import './App.css'
 import Header from './components/Header';
 import { BrowserRouter as Router, Route, Routes, Navigate } from 'react-router-dom';
 import PortfolioItems from './components/PortfolioItems';
-// import WorkExperience from './components/WorkExperience';
-// import Bio from './components/Bio'; 
 import Certifications from './components/Certifications';
 import HomeContent from './components/HomeContent';
-// import Footer from './components/Footer';
 import "./components/css/homecontent.css";
 import Article from './components/Article';
 import Contact from './components/Contact';
+import Redirect404Handler from './Redirect404Handler';
 
 function App() {
+
   return (
     <Router>
+
+      <Redirect404Handler/>
+  
       <div  style={{color:'#453c4a', backgroundColor: '#f5ebe6', minHeight: '100vh' }}>
       <Header />
 

--- a/portfolio/src/Redirect404Handler.jsx
+++ b/portfolio/src/Redirect404Handler.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function Redirect404Handler() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const redirectPath = new URLSearchParams(window.location.search).get('redirect');
+    if (redirectPath && window.location.pathname === '/') {
+      navigate(redirectPath, { replace: true });
+    }
+  }, [navigate]);
+
+  return null;
+}


### PR DESCRIPTION
	1. github looks for /abc/index.html if such URL is entered
	2. the resource is not found, github then invokes built-in behaviour of attempting to srve 404.html in root directory
	3. my 404 will make a redirect to /?redirect=/abc
	4. my app logic will then find this url search param and do another redirect (kind of internally) to /abc
	5. this redirect is handled by react/js itself
	6. the correct page is rendered